### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
                 <param name="onload" value="true" />
             </feature>
         </config-file>
-        <resource-file src="src/ios/GoogleService-Info.plist" />
+       <!-- <resource-file src="src/ios/GoogleService-Info.plist" /> -->
         <framework src="Foundation.framework"/>
         <framework src="AVFoundation.framework"/>
         <podspec>


### PR DESCRIPTION
iOS googleService file is brought in via configuration and doesn't need to be handled by this plugin that just overwrites it with a blank one.